### PR TITLE
Add a test suite and fix npm test, truncated piped output, and path shortening

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,1 @@
-/test
 node_modules

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,33 @@ versioning follows [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ---
 
+## [Unreleased]
+
+### Added
+
+- Zero-dependency test suite (`test/run.js`) that `npm test` now runs. Covers
+  the parser, hint matching, formatter, and both entry points (index + server).
+
+### Fixed
+
+- `npm test` failed out of the box: the `test` directory was gitignored and
+  `package.json` pointed at a test script that did not exist. The `.gitignore`
+  entry and the `test` script now reference the real suite.
+- `formatter.js` — a file path was shortened if it merely shared a textual
+  prefix with the current working directory (e.g. cwd `app` and file
+  `apple/x.js`). Paths are now only shortened when the file actually lives
+  inside cwd, checked on a path boundary.
+- `hints.js` — removed two hint entries that could never match:
+  `UnhandledPromiseRejection` (the rejection reason, never that literal string,
+  reaches `getHint`) and an `async`-specific undefined-read regex (no thrown
+  message can contain both "Cannot read" and "async").
+- `index.js` — stdout output was truncated when piped (e.g. `node script.js | cat`)
+  because `process.exit(1)` killed the process before buffered stdout flushed.
+  The exit code is now set via `process.exitCode` and the event loop is left to
+  drain, which Node.js docs recommend for exactly this reason.
+
+---
+
 ## [1.1.2] - 2026-04-20
 
 ### Changed

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -27,7 +27,7 @@ hint-errors/
 │   ├── parser.js     # extracts file, line, type from raw Error
 │   ├── hints.js      # matches errors to hints (ordered array)
 │   └── formatter.js  # renders the terminal output
-└── test/             # (add your own test files)
+└── test/             # test suite – run with `npm test`
 ```
 
 ## Adding a new hint
@@ -72,13 +72,16 @@ require("../index.js");
 // code that throws the error you're targeting
 ```
 
-Run it:
+Run the whole suite:
 
 ```bash
-node test/your-test.js
+npm test
 ```
 
-Verify the correct hint appears.
+Any `*.test.js` file inside `test/` is picked up automatically by the
+zero-dependency runner (`test/run.js`). Add one `test(...)` block per
+assertion — the runner prints a pass/fail report and exits non-zero on failure.
+Manually verify the correct hint appears for a quick check while writing it.
 
 ## Code style
 

--- a/index.js
+++ b/index.js
@@ -41,13 +41,15 @@ function handle(err) {
 /**
  * Handles synchronous uncaught exceptions — errors that were thrown
  * somewhere in the codebase but never caught by a try/catch block.
- * process.exit(1) is called after formatting because Node's own docs
- * state the process should not continue after an uncaughtException as
- * the application is in an undefined state.
+ * The exit code is set to 1 after formatting and the process is left to
+ * drain naturally instead of calling process.exit(1): calling process.exit()
+ * can terminate the process before async stdout writes (e.g. when piped)
+ * have flushed, silently dropping the hint. Node.js docs recommend setting
+ * process.exitCode and letting the event loop drain for this reason.
  */
 process.on("uncaughtException", (err) => {
   handle(err);
-  process.exit(1);
+  process.exitCode = 1;
 });
 
 /**
@@ -55,9 +57,11 @@ process.on("uncaughtException", (err) => {
  * with no .catch() handler or try/catch around their await call.
  * The rejection reason can technically be any value, so non-Error reasons
  * are normalized into a real Error object before being passed to handle().
+ * Same exit strategy as uncaughtException: set the exit code and let the
+ * event loop drain so stdout is not truncated.
  */
 process.on("unhandledRejection", (reason) => {
   const err = reason instanceof Error ? reason : new Error(String(reason));
   handle(err);
-  process.exit(1);
+  process.exitCode = 1;
 });

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "README.md"
   ],
   "scripts": {
-    "test": "node test/script.js"
+    "test": "node test/run.js"
   },
   "keywords": [
     "error",

--- a/src/formatter.js
+++ b/src/formatter.js
@@ -23,10 +23,12 @@ const c = {
 
 /**
  * Shortens an absolute file path to be relative to the current working
- * directory. Comparison is done case-insensitively to handle Windows drive
- * letter casing differences (e.g. process.cwd() returns "F:\" but the stack
- * trace path may start with "f:\"). The returned path preserves the
- * original casing of the input.
+ * directory. A path is only shortened when it actually lives inside cwd —
+ * matching is done on a path boundary so a sibling directory that merely
+ * shares a prefix with cwd (e.g. cwd "app" vs "apple/") is never truncated.
+ * Comparison is done case-insensitively to handle Windows drive letter casing
+ * differences (e.g. process.cwd() returns "F:\" but the stack trace path may
+ * start with "f:\"). The returned path preserves the original casing.
  *
  * @param {string|null} filePath - The absolute file path extracted from the stack trace.
  * @returns {string} The path relative to cwd, or the original path if it falls
@@ -34,11 +36,24 @@ const c = {
  */
 function shortenPath(filePath) {
   if (!filePath) return "unknown location";
-  const cwd = process.cwd().toLowerCase();
-  const normalizedFile = filePath.toLowerCase();
-  return normalizedFile.startsWith(cwd)
-    ? filePath.slice(cwd.length + 1)
-    : filePath;
+  const cwd = process.cwd();
+  const cwdLower = cwd.toLowerCase();
+  const fileLower = filePath.toLowerCase();
+
+  if (!fileLower.startsWith(cwdLower)) return filePath;
+
+  // A path must actually live inside cwd to be shortened. When cwd does not
+  // end in a separator, the next character must be one — this prevents a
+  // sibling directory that merely shares a textual prefix with cwd (e.g. cwd
+  // "app" vs "apple/") from having its leading characters silently chopped.
+  const cwdEndsWithSeparator = cwd.endsWith("/") || cwd.endsWith("\\");
+  const rest = fileLower.slice(cwdLower.length);
+  if (rest === "") return filePath;
+  if (!cwdEndsWithSeparator && rest[0] !== "/" && rest[0] !== "\\") {
+    return filePath;
+  }
+
+  return filePath.slice(cwdLower.length + (cwdEndsWithSeparator ? 0 : 1));
 }
 
 /**

--- a/src/hints.js
+++ b/src/hints.js
@@ -320,17 +320,6 @@ Check that the IP or hostname is correct and that your machine can reach that ne
   },
 
   // ─── Promises / Async ──────────────────────────────────────────
-  {
-    match: "UnhandledPromiseRejection",
-    hint: `A promise was rejected but nothing caught the error.
-Add a .catch() to your promise chain, or wrap your await call in a try/catch block.`,
-  },
-  {
-    match: /Cannot read.*of undefined.*async|async.*Cannot read.*of undefined/,
-    hint: `This error happened inside an async function — the value you're reading is undefined.
-Make sure you're awaiting the function that returns the data before trying to use it.
-A missing 'await' keyword is a very common cause of this.`,
-  },
 ];
 
 /**

--- a/test/formatter.test.js
+++ b/test/formatter.test.js
@@ -1,0 +1,112 @@
+// test/formatter.test.js
+"use strict";
+const assert = require("assert");
+const os = require("os");
+const path = require("path");
+const fs = require("fs");
+const { formatError } = require("../src/formatter.js");
+
+// Captures whatever formatError writes to stdout so the rendered block can be
+// asserted without polluting the test runner's own output.
+function capture(fn) {
+  const chunks = [];
+  const original = process.stdout.write.bind(process.stdout);
+  process.stdout.write = (chunk) => {
+    chunks.push(chunk);
+    return true;
+  };
+  try {
+    fn();
+  } finally {
+    process.stdout.write = original;
+  }
+  return chunks.join("");
+}
+
+test("renders error type, message, location and hint", () => {
+  const out = capture(() =>
+    formatError(
+      { type: "TypeError", message: "boom", file: "/app/x.js", line: "3", raw: null },
+      "look here",
+    ),
+  );
+  assert.ok(out.includes("TypeError"));
+  assert.ok(out.includes("boom"));
+  assert.ok(out.includes("/app/x.js"));
+  assert.ok(out.includes("look here"));
+});
+
+test("renders an unknown location when no file is present", () => {
+  const out = capture(() =>
+    formatError({ type: "Error", message: "boom", file: null, line: null, raw: null }, "hi"),
+  );
+  assert.ok(out.includes("unknown location"));
+});
+
+test("shortens paths that live inside the current working directory", () => {
+  const cwd = process.cwd();
+  const out = capture(() =>
+    formatError(
+      { type: "Error", message: "boom", file: path.join(cwd, "src", "deep", "x.js"), line: "1", raw: null },
+      "hi",
+    ),
+  );
+  assert.ok(out.includes(path.join("src", "deep", "x.js")), "should be relative to cwd");
+});
+
+test("does NOT shorten a sibling directory that merely shares a prefix with cwd", () => {
+  // macOS resolves os.tmpdir() (/var) to a real path (/private/var) when you
+  // chdir into it, so resolve once to keep cwd and file on the same root.
+  const tmp = fs.realpathSync(fs.mkdtempSync(path.join(os.tmpdir(), "hint-errors-test-")));
+  const cwdDir = path.join(tmp, "app");
+  const siblingDir = path.join(tmp, "apple"); // "app" + "le" — shares prefix "app"
+  fs.mkdirSync(cwdDir);
+  fs.mkdirSync(siblingDir);
+
+  const originalCwd = process.cwd();
+  process.chdir(cwdDir);
+  try {
+    const file = path.join(siblingDir, "x.js");
+    const out = capture(() =>
+      formatError({ type: "Error", message: "boom", file, line: "1", raw: null }, "hi"),
+    );
+    assert.ok(
+      out.includes(file),
+      `expected the full sibling path to stay intact, got: ${out}`,
+    );
+  } finally {
+    process.chdir(originalCwd);
+    fs.rmSync(tmp, { recursive: true, force: true });
+  }
+});
+
+test("shortens Windows paths regardless of drive-letter case", () => {
+  const originalCwd = process.cwd;
+  process.cwd = () => "F:\\MyApp";
+  try {
+    const out = capture(() =>
+      formatError(
+        { type: "Error", message: "boom", file: "f:\\MyApp\\src\\x.js", line: "1", raw: null },
+        "hi",
+      ),
+    );
+    assert.ok(out.includes("src\\x.js"), `expected a relative path, got: ${out}`);
+    assert.ok(!out.includes("F:\\"), "expected the cwd prefix to be stripped");
+  } finally {
+    process.cwd = originalCwd;
+  }
+});
+
+test("keeps Windows paths that only share a prefix with cwd intact", () => {
+  const originalCwd = process.cwd;
+  process.cwd = () => "F:\\MyApp";
+  try {
+    const file = "f:\\MyAppx\\y.js";
+    const out = capture(() =>
+      formatError({ type: "Error", message: "boom", file, line: "1", raw: null }, "hi"),
+    );
+    assert.ok(out.includes(file), `expected the full path, got: ${out}`);
+  } finally {
+    process.cwd = originalCwd;
+  }
+});

--- a/test/hints.test.js
+++ b/test/hints.test.js
@@ -1,0 +1,87 @@
+// test/hints.test.js
+"use strict";
+const assert = require("assert");
+const { getHint } = require("../src/hints.js");
+
+test("returns a specific hint for undefined property reads", () => {
+  const hint = getHint({
+    type: "TypeError",
+    message: "Cannot read properties of undefined (reading 'name')",
+  });
+  assert.ok(/defined/.test(hint), "hint should mention the value being undefined");
+});
+
+test("returns a specific hint for null property reads", () => {
+  const hint = getHint({
+    type: "TypeError",
+    message: "Cannot read properties of null (reading 'length')",
+  });
+  assert.ok(/defined/.test(hint), "hint should mention the value being undefined");
+});
+
+test("returns a specific hint for non-function calls", () => {
+  const hint = getHint({
+    type: "TypeError",
+    message: "x.y is not a function",
+  });
+  assert.ok(/function/.test(hint), "hint should mention functions");
+});
+
+test("returns a specific hint for window being undefined", () => {
+  const hint = getHint({
+    type: "ReferenceError",
+    message: "window is not defined",
+  });
+  assert.ok(/window/.test(hint), "hint should mention window");
+});
+
+test("returns a specific hint for missing files", () => {
+  const hint = getHint({
+    type: "Error",
+    message: "ENOENT: no such file or directory, open '/tmp/nope.txt'",
+  });
+  assert.ok(/file|ENOENT/.test(hint), "hint should mention the missing file");
+});
+
+test("returns a specific hint for port conflicts", () => {
+  const hint = getHint({
+    type: "Error",
+    message: "EADDRINUSE: address already in use :::3000",
+  });
+  assert.ok(/port/i.test(hint), "hint should mention the port");
+});
+
+test("returns a specific hint for max call stack", () => {
+  const hint = getHint({
+    type: "RangeError",
+    message: "Maximum call stack size exceeded",
+  });
+  assert.ok(/stack|recurs/.test(hint), "hint should mention the call stack");
+});
+
+test("falls back to the generic hint for unmatched errors", () => {
+  const hint = getHint({
+    type: "Error",
+    message: "some exotic thing went sideways",
+  });
+  assert.ok(hint.length > 0);
+});
+
+test("async undefined-read hint is not reachable from a plain message (dead entry removed)", () => {
+  const hint = getHint({
+    type: "TypeError",
+    message: "Cannot read properties of undefined (reading 'x')",
+  });
+  assert.ok(
+    !/await/i.test(hint),
+    "a plain thrown message must not hit the async-specific hint",
+  );
+});
+
+test("unhandled rejection reasons still get the generic pipeline hint", () => {
+  const hint = getHint({
+    type: "Error",
+    message: "boom from a rejected promise",
+  });
+  assert.ok(hint.length > 0);
+});

--- a/test/integration.test.js
+++ b/test/integration.test.js
@@ -1,0 +1,72 @@
+// test/integration.test.js
+"use strict";
+const assert = require("assert");
+const path = require("path");
+const { spawnSync } = require("child_process");
+
+const indexEntry = JSON.stringify(path.join(__dirname, "..", "index.js"));
+const serverEntry = JSON.stringify(path.join(__dirname, "..", "server.js"));
+
+// A script that requires index.js and then throws. The thrown error's message
+// is padded far past the OS pipe buffer so any truncation from a premature
+// process.exit(1) shows up as a missing hint at the end of the output.
+function indexThrowScript() {
+  return `
+    require(${indexEntry});
+    const err = new TypeError("Cannot read properties of undefined (reading 'x')");
+    err.message += " | " + "x".repeat(200000);
+    throw err;
+  `;
+}
+
+test("index mode prints the hint and exits with code 1", () => {
+  const res = spawnSync(process.execPath, ["-e", indexThrowScript()], {
+    encoding: "utf8",
+  });
+  assert.strictEqual(res.status, 1, `expected exit code 1, got ${res.status}`);
+  assert.ok(res.stdout.includes("doesn't exist yet"), "hint text should be present");
+  assert.ok(res.stdout.includes("TypeError"));
+});
+
+test("index mode exits 1 on unhandled promise rejections too", () => {
+  const script = `
+    require(${indexEntry});
+    Promise.reject(new Error("boom from a rejected promise"));
+  `;
+  const res = spawnSync(process.execPath, ["-e", script], { encoding: "utf8" });
+  assert.strictEqual(res.status, 1, `expected exit code 1, got ${res.status}`);
+  assert.ok(res.stdout.includes("boom from a rejected promise"));
+});
+
+test("server mode stays alive after an uncaught error", () => {
+  const script = `
+    require(${serverEntry});
+    setInterval(() => {}, 1000);
+    throw new Error("boom");
+  `;
+  // The child never exits on its own (server mode survives the error), so a
+  // spawnSync timeout is what stops it. If it had exited on its own, status
+  // would be non-null — signalling the process died after the uncaught error.
+  const res = spawnSync(process.execPath, ["-e", script], {
+    encoding: "utf8",
+    timeout: 1500,
+  });
+  assert.strictEqual(
+    res.status,
+    null,
+    `server mode must stay alive after an uncaught error (status was ${res.status}, signal ${res.signal})`,
+  );
+  assert.strictEqual(res.signal, "SIGTERM");
+  assert.ok(res.stdout.includes("boom"), "hint block should still be printed");
+});
+
+test("large output is not truncated when piped (stdout flush race)", () => {
+  const res = spawnSync(process.execPath, ["-e", indexThrowScript()], {
+    encoding: "utf8",
+  });
+  assert.ok(
+    res.stdout.includes("doesn't exist yet"),
+    "formatted hint must not be truncated when piped",
+  );
+  assert.ok(res.stdout.length > 200000, `expected the large message to survive, got ${res.stdout.length} bytes`);
+});

--- a/test/parser.test.js
+++ b/test/parser.test.js
@@ -1,0 +1,66 @@
+// test/parser.test.js
+"use strict";
+const assert = require("assert");
+const { parseError } = require("../src/parser.js");
+
+test("extracts type and message from a TypeError", () => {
+  const parsed = parseError(new TypeError("boom"));
+  assert.strictEqual(parsed.type, "TypeError");
+  assert.strictEqual(parsed.message, "boom");
+});
+
+test("extracts file and line from the first user frame", () => {
+  const err = new Error("boom");
+  err.stack = [
+    "Error: boom",
+    "    at Object.<anonymous> (/app/src/x.js:12:5)",
+    "    at Module._compile (node:internal/modules/cjs/loader:999:22)",
+  ].join("\n");
+  const parsed = parseError(err);
+  assert.strictEqual(parsed.file, "/app/src/x.js");
+  assert.strictEqual(parsed.line, "12");
+});
+
+test("filters node internals and node_modules frames", () => {
+  const err = new Error("boom");
+  err.stack = [
+    "Error: boom",
+    "    at Object.<anonymous> (node:internal/modules/cjs/loader:999:22)",
+    "    at Foo.bar (/app/node_modules/dep/lib/index.js:5:3)",
+    "    at Object.<anonymous> (/app/src/index.js:3:1)",
+  ].join("\n");
+  const parsed = parseError(err);
+  assert.strictEqual(parsed.file, "/app/src/index.js");
+  assert.strictEqual(parsed.line, "3");
+});
+
+test("falls back to null file/line when only internal frames exist", () => {
+  const err = new Error("boom");
+  err.stack = [
+    "Error: boom",
+    "    at Object.<anonymous> (node:internal/main/run_main_module:17:47)",
+  ].join("\n");
+  const parsed = parseError(err);
+  assert.strictEqual(parsed.file, null);
+  assert.strictEqual(parsed.line, null);
+});
+
+test("normalizes non-Error throw values", () => {
+  const parsed = parseError("oops");
+  assert.strictEqual(parsed.type, "Error");
+  assert.strictEqual(parsed.message, "oops");
+  assert.strictEqual(parsed.file, null);
+  assert.strictEqual(parsed.line, null);
+  assert.strictEqual(parsed.raw, "oops");
+});
+
+test("uses fallback message for errors with an empty message", () => {
+  const parsed = parseError(new Error("   "));
+  assert.strictEqual(parsed.message, "An unknown error occurred");
+});
+
+test("preserves the original value on raw", () => {
+  const err = new Error("boom");
+  const parsed = parseError(err);
+  assert.strictEqual(parsed.raw, err);
+});

--- a/test/run.js
+++ b/test/run.js
@@ -1,0 +1,38 @@
+// test/run.js
+"use strict";
+
+// Zero-dependency test runner. Discovers every *.test.js file inside test/
+// and runs the `test(name, fn)` blocks it finds, then prints a pass/fail
+// report and exits non-zero if anything failed.
+const fs = require("fs");
+const path = require("path");
+
+const tests = [];
+global.test = (name, fn) => tests.push({ name, fn });
+
+const dir = __dirname;
+for (const entry of fs.readdirSync(dir).sort()) {
+  if (entry.endsWith(".test.js")) {
+    require(path.join(dir, entry));
+  }
+}
+
+(async () => {
+  let passed = 0;
+  let failed = 0;
+  for (const { name, fn } of tests) {
+    try {
+      await fn();
+      passed += 1;
+      console.log(`  ok   ${name}`);
+    } catch (err) {
+      failed += 1;
+      console.error(`  FAIL ${name}`);
+      console.error(`--- ${name} ---`);
+      console.error(err && err.stack ? err.stack : String(err));
+    }
+  }
+
+  console.log(`\n${passed} passed, ${failed} failed`);
+  process.exitCode = failed > 0 ? 1 : 0;
+})();


### PR DESCRIPTION
## Summary

This PR makes the project testable and fixes three real bugs that the new suite surfaced (plus one dead-code cleanup). All changes are zero-dependency, following the repo's existing style.

### What's included

1. **A zero-dependency test suite** (`test/run.js`) — a ~30-line runner that discovers `*.test.js` files and reports pass/fail with a non-zero exit on failure. It covers the parser, hint matching, formatter (incl. Windows paths), and both entry points (`index.js` and `server.js`) end-to-end via subprocesses.

2. **Fix `npm test`** — `package.json` pointed at `node test/script.js`, which never existed, and `.gitignore` excluded the whole `test/` directory. Fixes [#2](https://github.com/ZLouisMiguel/hint-errors/issues/2).

3. **Fix truncated piped output** — `index.js` called `process.exit(1)` before buffered stdout flushed, silently dropping the hint whenever stdout was a pipe. Now sets `process.exitCode` and lets the event loop drain (the pattern Node.js docs recommend). Fixes [#3](https://github.com/ZLouisMiguel/hint-errors/issues/3).

4. **Fix path shortening** — `shortenPath` chopped the cwd prefix off any path that merely shared a text prefix with it (`apple/x.js` became `e/x.js` when cwd was `app`). Paths are now only shortened when the file genuinely lives inside cwd, matched on a path boundary. Fixes [#4](https://github.com/ZLouisMiguel/hint-errors/issues/4).

5. **Remove unreachable hints** — two `hints.js` entries could never match: the `UnhandledPromiseRejection` string (rejection reasons, not that literal string, reach `getHint`) and an async-specific undefined-read regex (no thrown message contains both "Cannot read" and "async").

### Tests

```bash
npm test   # 27 passed, 0 failed
```

Each fix ships with a regression test, and I mutation-tested the suite to confirm the two formatter/exit bugs are actually caught by the tests, not just described.

### Commit history

Five focused commits, each green on its own: test runner + `npm test` fix → formatter fix → hints cleanup → exit-flush fix → docs.

Happy to split this differently or adjust anything to match your preferences.